### PR TITLE
Inkludere secretmanager.googleapis.com i outbound accessPolicy

### DIFF
--- a/nais/naiserator-dev.yml
+++ b/nais/naiserator-dev.yml
@@ -64,3 +64,4 @@ spec:
     outbound:
       external:
         - host: api.difitest.signering.posten.no
+        - host: secretmanager.googleapis.com

--- a/nais/naiserator-prod.yml
+++ b/nais/naiserator-prod.yml
@@ -60,3 +60,4 @@ spec:
     outbound:
       external:
         - host: api.signering.posten.no
+        - host: secretmanager.googleapis.com


### PR DESCRIPTION
Åpnet via en urelatert ekstern app tidligere. Denne ble fjernet 24.02 slik at tilgang til secret-manager ble stoppet