### PR TITLE
Fjerne døde miljiøvariabler for b2c (loginservice)

### DIFF
--- a/.nais/apps/api/feature.yml
+++ b/.nais/apps/api/feature.yml
@@ -16,10 +16,6 @@ env:
     value: https://api-gw-q1.oera.no
   - name: BRUKERNOTIFIKASJON_PAA
     value: "true"
-  - name: DISCOVERY_URL
-    value: https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-  - name: AUD_FP
-    value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
   - name: DB_USER_ASYNKRON
     value: asynkron_feature
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID

--- a/.nais/apps/api/main.yml
+++ b/.nais/apps/api/main.yml
@@ -16,10 +16,6 @@ env:
     value: https://api-gw-q1.oera.no
   - name: BRUKERNOTIFIKASJON_PAA
     value: "true"
-  - name: DISCOVERY_URL
-    value: https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-  - name: AUD_FP
-    value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
   - name: DB_USER_ASYNKRON
     value: asynkron_main
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID

--- a/.nais/apps/api/prod.yml
+++ b/.nais/apps/api/prod.yml
@@ -18,10 +18,6 @@ env:
     value: https://api-gw.oera.no
   - name: BRUKERNOTIFIKASJON_PAA
     value: "true"
-  - name: DISCOVERY_URL
-    value: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-  - name: AUD_FP
-    value: f45035f2-9a27-46f7-917c-0569a03285cd
   - name: DB_USER_ASYNKRON
     value: asynkron_prod
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID

--- a/.nais/apps/asynkron/feature.yml
+++ b/.nais/apps/asynkron/feature.yml
@@ -13,10 +13,6 @@ env:
     value: farskapsportaldb-feature
   - name: DEAKTIVERINGSRATE
     value: "0 0/15 * * * ?"
-  - name: DISCOVERY_URL
-    value: https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-  - name: AUD_FP
-    value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID
     value: "627047445397"
   - name: VIRKSOMHETSSERTIFIKAT_HEMMELIGHET_NAVN

--- a/.nais/apps/asynkron/main.yml
+++ b/.nais/apps/asynkron/main.yml
@@ -13,10 +13,6 @@ env:
     value: fpdb-main
   - name: DEAKTIVERINGSRATE
     value: "0 15 13 * * ?"
-  - name: DISCOVERY_URL
-    value: https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1
-  - name: AUD_FP
-    value: 0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID
     value: "719909854975"
   - name: VIRKSOMHETSSERTIFIKAT_HEMMELIGHET_NAVN

--- a/.nais/apps/asynkron/prod.yml
+++ b/.nais/apps/asynkron/prod.yml
@@ -16,10 +16,6 @@ env:
     value: fpdb-prod
   - name: DEAKTIVERINGSRATE
     value: "0 30 13 * * ?"
-  - name: DISCOVERY_URL
-    value: https://navnob2c.b2clogin.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten
-  - name: AUD_FP
-    value: f45035f2-9a27-46f7-917c-0569a03285cd
   - name: VIRKSOMHETSSERTIFIKAT_PROSJEKT_ID
     value: "642182003125"
   - name: VIRKSOMHETSSERTIFIKAT_HEMMELIGHET_NAVN


### PR DESCRIPTION
farskapsportal-api henter LOGINSERVICE_IDPORTEN_AUDIENCE og LOGINSERVICE_IDPORTEN_DISCOVERY_URL fra ConfigMap loginservice-idporten